### PR TITLE
Add Advent of Code 2025 boilerplate

### DIFF
--- a/projects/advent-of-code/2025/README.md
+++ b/projects/advent-of-code/2025/README.md
@@ -1,0 +1,3 @@
+# Advent of Code 2025
+
+[Link](https://adventofcode.com/2025)

--- a/projects/advent-of-code/2025/new.py
+++ b/projects/advent-of-code/2025/new.py
@@ -1,0 +1,50 @@
+import os
+import sys
+from shutil import copyfile
+
+
+class printc:
+  bright = '\033[1;36m'
+  error = '\033[1;31m'
+  gray = '\033[90m'
+  normal = '\033[0m'
+  warning = '\033[1;33m'
+
+  def color(color, value): print(f'{color}{value}{printc.normal}')
+  def act(value): printc.color(printc.bright, value)
+  def cmd(value): printc.color(printc.gray, value)
+  def err(value): printc.color(printc.error, value)
+  def war(value): printc.color(printc.warning, value)
+
+
+if len(sys.argv) <= 1:
+  printc.war('Folder name requred.')
+  printc.cmd('Usage: python3 new.py 06')
+  sys.exit()
+
+scriptPath = os.path.dirname(os.path.abspath(__file__))
+folderPath = f'{scriptPath}/{sys.argv[1]}'
+editor = sys.argv[2] if len(sys.argv) > 2 else 'code'
+
+if os.path.isdir(folderPath):
+  printc.war('Folder already exists.')
+  printc.cmd(folderPath)
+  sys.exit()
+
+printc.act('Creating new folder and files...')
+
+templatePath = f'{scriptPath}/template.py'
+part1Path = f'{folderPath}/part1.py'
+testPath = f'{folderPath}/test.txt'
+inputPath = f'{folderPath}/input.txt'
+
+os.mkdir(folderPath)
+copyfile(templatePath, part1Path)
+open(testPath, 'a').close()
+open(inputPath, 'a').close()
+
+os.system(f'{editor} {part1Path}')
+os.system(f'{editor} {testPath}')
+os.system(f'{editor} {inputPath}')
+
+print('Done!')

--- a/projects/advent-of-code/2025/template.py
+++ b/projects/advent-of-code/2025/template.py
@@ -1,0 +1,16 @@
+from os import path
+
+scriptPath = path.dirname(path.abspath(__file__))
+inputPath = scriptPath + '/test.txt'
+
+
+def main():
+  pass
+
+
+def readInput():
+  with open(inputPath) as file:
+    return file.read().splitlines()
+
+
+main()


### PR DESCRIPTION
Create boilerplate for AOC 2025 based on 2024 structure:
- README.md with link to AOC 2025
- template.py for daily solutions
- new.py script to generate day folders

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Introduce Advent of Code 2025 boilerplate with a template and a script to generate per-day folders/files.
> 
> - **Boilerplate for `projects/advent-of-code/2025`**:
>   - `README.md` with link to AoC 2025.
>   - `template.py` providing `main()` and `readInput()` (reads from `test.txt`).
> - **Utility script `new.py`**:
>   - Generates a new day folder with `part1.py` (from `template.py`), `test.txt`, and `input.txt`.
>   - Validates args and existing folders; opens created files in the chosen editor; colored console output.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 4c28eae1b4ccbdf2478b39df789dc5a936a33699. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->